### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/licenserc.toml
+++ b/licenserc.toml
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-headerPath = "Apache-2.0.txt"
+[header]
+builtin = "Apache-2.0"
 
+[files]
+excludes = [
+  # rustfmt removes the separator that HawkEye writes after this header-only placeholder.
+  "template/src/lib.rs",
+]
 includes = ['**/*.proto', '**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']
 
-[properties]
-copyrightOwner = "FastLabs Developers"
-inceptionYear = 2024
+[props]
+copyright_owner = "FastLabs Developers"
+inception_year = 2024

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -173,7 +173,7 @@ fn make_hawkeye_cmd(fix: bool) -> StdCommand {
     ensure_installed("hawkeye", "hawkeye");
     let mut cmd = find_command("hawkeye");
     if fix {
-        cmd.args(["format", "--fail-if-updated=false"]);
+        cmd.args(["format"]);
     } else {
         cmd.args(["check"]);
     }


### PR DESCRIPTION
## Summary

- migrate the HawkEye configuration and integration to v7
- install HawkEye from its latest release without pinning the tool version
- validate the migrated configuration with HawkEye v7 (12 files, 0 changes, 0 conflicts, 0 unsupported)
- exclude one header-only Rust placeholder where HawkEye's separator conflicts with `rustfmt`
- `cargo x lint` passes